### PR TITLE
feat: support type=triage in resource_workflow_state

### DIFF
--- a/internal/provider/resource_workflow_state.go
+++ b/internal/provider/resource_workflow_state.go
@@ -68,7 +68,7 @@ func (r *WorkflowStateResource) Schema(ctx context.Context, req resource.SchemaR
 					stringplanmodifier.RequiresReplace(),
 				},
 				Validators: []validator.String{
-					stringvalidator.OneOf([]string{"backlog", "unstarted", "started", "completed", "canceled"}...),
+					stringvalidator.OneOf([]string{"triage", "backlog", "unstarted", "started", "completed", "canceled"}...),
 				},
 			},
 			"position": schema.NumberAttribute{


### PR DESCRIPTION
The docs mention it supports triage:

<img width="1085" alt="image" src="https://github.com/user-attachments/assets/51b6ca3e-2bc5-4326-b564-3e27189b527d" />

https://studio.apollographql.com/public/Linear-API/variant/current/schema/reference/objects/WorkflowState?query=workflowstate