### PR TITLE
Fix: Allow non-admin users to update teams

### DIFF
--- a/internal/provider/generated.go
+++ b/internal/provider/generated.go
@@ -1013,9 +1013,9 @@ type TeamUpdateInput struct {
 	// The workflow state into which issues are moved when they are marked as a duplicate of another issue.
 	MarkedAsDuplicateWorkflowStateId string `json:"markedAsDuplicateWorkflowStateId,omitempty"`
 	// Whether new users should join this team by default. Mutation restricted to workspace admins!
-	JoinByDefault bool `json:"joinByDefault"`
+	JoinByDefault *bool `json:"joinByDefault,omitempty"`
 	// Whether the team is managed by SCIM integration. Mutation restricted to workspace admins and only unsetting is allowed!
-	ScimManaged bool `json:"scimManaged"`
+	ScimManaged *bool `json:"scimManaged,omitempty"`
 	// The parent team ID.
 	ParentId *string `json:"parentId"`
 	// [Internal] Whether the team should inherit workflow statuses from its parent.
@@ -1156,10 +1156,10 @@ func (v *TeamUpdateInput) GetMarkedAsDuplicateWorkflowStateId() string {
 }
 
 // GetJoinByDefault returns TeamUpdateInput.JoinByDefault, and is useful for accessing the field via an interface.
-func (v *TeamUpdateInput) GetJoinByDefault() bool { return v.JoinByDefault }
+func (v *TeamUpdateInput) GetJoinByDefault() *bool { return v.JoinByDefault }
 
 // GetScimManaged returns TeamUpdateInput.ScimManaged, and is useful for accessing the field via an interface.
-func (v *TeamUpdateInput) GetScimManaged() bool { return v.ScimManaged }
+func (v *TeamUpdateInput) GetScimManaged() *bool { return v.ScimManaged }
 
 // GetParentId returns TeamUpdateInput.ParentId, and is useful for accessing the field via an interface.
 func (v *TeamUpdateInput) GetParentId() *string { return v.ParentId }

--- a/internal/provider/resource_team.graphql
+++ b/internal/provider/resource_team.graphql
@@ -81,6 +81,8 @@ mutation createTeam(
 # @genqlient(for: "TeamUpdateInput.markedAsDuplicateWorkflowStateId", omitempty: true)
 # @genqlient(for: "TeamUpdateInput.autoCloseStateId", omitempty: true)
 # @genqlient(for: "TeamUpdateInput.productIntelligenceScope", omitempty: true)
+# @genqlient(for: "TeamUpdateInput.joinByDefault", pointer: true, omitempty: true)
+# @genqlient(for: "TeamUpdateInput.scimManaged", pointer: true, omitempty: true)
 mutation updateTeam(
   $input: TeamUpdateInput!,
   $id: String!


### PR DESCRIPTION
## Summary

This PR fixes a bug where non-admin users cannot update teams due to admin-only fields (`joinByDefault` and `scimManaged`) being sent with `false` values in every team update request.

## Problem

The provider was sending `joinByDefault: false` and `scimManaged: false` on every team update operation, even though these fields are not exposed in the Terraform schema. The Linear API requires these fields to be **undefined (omitted from JSON)** for non-admin users, not set to `false`.

This caused the error:
```
Error: Unable to update team, got error: input:3: teamUpdate Invalid role: admin required
```

## Solution

Changed the admin-only boolean fields to pointer types with `omitempty` JSON tags:
- `JoinByDefault bool` → `JoinByDefault *bool` with `json:"joinByDefault,omitempty"`
- `ScimManaged bool` → `ScimManaged *bool` with `json:"scimManaged,omitempty"`
- Updated corresponding getter functions to return `*bool`

Since these fields are not exposed in the Terraform schema and are never set in the provider code, they will always be `nil` and will be omitted from API requests (thanks to `omitempty`), allowing non-admin users to successfully update teams.

## Evidence

Linear support confirmed:
> "You are trying to set joinByDefault and scimManaged. You need to be an admin to set either of those properties on a team. You would need to pass undefined in the input for those values instead of false."

MITM capture of the update request showed these fields being sent as `false` even when not configured in Terraform.

## Testing

- ✅ Code compiles successfully with `go build`
- ✅ Fields are not set in `resource_team.go` (they're not exposed in the schema)
- ✅ Pointer types with `omitempty` will omit the fields from JSON when `nil`

## Impact

This allows non-admin users to use the Terraform provider to manage teams, which is critical for organizations that don't give admin access to infrastructure automation accounts.

## Files Changed

- `internal/provider/generated.go`: Updated `TeamUpdateInput` struct and getter functions