### PR TITLE
fix: handle 'Entity not found' in team Read by removing from state

### DIFF
--- a/internal/provider/resource_team.go
+++ b/internal/provider/resource_team.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 	"regexp"
 	"sort"
 
@@ -911,6 +912,13 @@ func (r *TeamResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	response, err := getTeam(ctx, *r.client, data.Key.ValueString())
 
 	if err != nil {
+		// Linear's GraphQL API returns 'Entity not found: Team' when the
+		// team key doesn't match any existing team. This is distinct from
+		// connection errors which would not contain this specific message.
+		if strings.Contains(err.Error(), "Entity not found: Team") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team, got error: %s", err))
 		return
 	}


### PR DESCRIPTION
## Summary

When a team doesn't exist (deleted externally or never created), the `Read` function now removes the resource from state instead of returning a diagnostic error. This allows Terraform to detect the resource is gone and recreate it.

## Problem

The current `Read` function returns a diagnostic error when `getTeam` fails with "Entity not found":

```go
resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team, got error: %s", err))
```

This causes Terraform to treat it as a permanent error rather than detecting the resource no longer exists. Tools like Crossplane/upjet that rely on `terraform apply -refresh-only` to detect resource existence get stuck in an error loop.

## Fix

Check if the error contains "Entity not found" and call `resp.State.RemoveResource()` to signal the resource no longer exists:

```go
if strings.Contains(err.Error(), "Entity not found") {
    resp.State.RemoveResource(ctx)
    return
}
```

This follows the [Terraform Plugin Framework best practice for Read](https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations):

> If the resource is no longer found, call `resp.State.RemoveResource()` to signal Terraform that the resource has been deleted.